### PR TITLE
[MAC-276] Support the new permissions schema in MacOS Big Sur

### DIFF
--- a/src/commands/add-permission.yml
+++ b/src/commands/add-permission.yml
@@ -12,8 +12,14 @@ steps:
       command: |
           if csrutil status | grep -q 'disabled'; then
               epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))
-              sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"<< parameters.permission-type >>\",\"<< parameters.bundle-id >>\",0,1,1,\"UNUSED\",0,$epochdate);"
-              sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"<< parameters.permission-type >>\",\"<< parameters.bundle-id >>\",0,1,1,\"UNUSED\",0,$epochdate);"
+              macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+              if [[ $macos_major_version -le 10 ]]; then
+                  tcc_update="replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"<< parameters.permission-type >>\",\"<< parameters.bundle-id >>\",0,1,1,\"UNUSED\",0,$epochdate);"
+              else
+                  tcc_update="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier,flags,last_modified) values (\"<< parameters.permission-type >>\",\"<< parameters.bundle-id >>\",0,2,1,1,\"UNUSED\",0,$epochdate);"
+              fi
+              sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_update"
+              sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_update"
           else
               echo "Unable to add permissions! System Integrity Protection is enabled on this image"
               echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"

--- a/src/commands/add-uitest-permissions.yml
+++ b/src/commands/add-uitest-permissions.yml
@@ -6,10 +6,18 @@ steps:
       command: |
           if csrutil status | grep -q 'disabled'; then
               epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))
-              sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"com.apple.dt.Xcode-Helper\",0,1,1,\"UNUSED\",0,$epochdate);"
-              sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"com.apple.dt.Xcode-Helper\",0,1,1,\"UNUSED\",0,$epochdate);"
-              sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceDeveloperTool\",\"com.apple.Terminal\",0,1,1,\"UNUSED\",0,$epochdate);"
-              sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceDeveloperTool\",\"com.apple.Terminal\",0,1,1,\"UNUSED\",0,$epochdate);"
+              macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+              if [[ $macos_major_version -le 10 ]]; then
+                  tcc_service_accessibility="replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"com.apple.dt.Xcode-Helper\",0,1,1,\"UNUSED\",0,$epochdate);"
+                  tcc_service_developer_tool="replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceDeveloperTool\",\"com.apple.Terminal\",0,1,1,\"UNUSED\",0,$epochdate);"
+              else
+                  tcc_service_accessibility="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"com.apple.dt.Xcode-Helper\",0,2,1,1,\"UNUSED\",0,$epochdate);"
+                  tcc_service_developer_tool="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceDeveloperTool\",\"com.apple.Terminal\",0,2,1,1,\"UNUSED\",0,$epochdate);"
+              fi
+              sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
+              sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
+              sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_developer_tool"
+              sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_developer_tool"
           else
               echo "Unable to add permissions! System Integrity Protection is enabled on this image"
               echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"

--- a/src/commands/list-permissions.yml
+++ b/src/commands/list-permissions.yml
@@ -2,7 +2,21 @@ description: Lists the currently defined permissions in the permissions database
 steps:
     - run:
         name: Listing currently defined permissions in user database
-        command: sudo sqlite3 -column -header "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "select client,service,allowed from access"
+        command: |
+            macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+            if [[ $macos_major_version -le 10 ]]; then
+                select_query="select client,service,allowed from access"
+            else
+                select_query="select client,service,auth_value from access"
+            fi
+            sudo sqlite3 -column -header "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$select_query"
     - run:
         name: Listing currently defined permissions in system database
-        command: sudo sqlite3 -column -header "/Library/Application Support/com.apple.TCC/TCC.db" "select client,service,allowed from access"
+        command: |
+            macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+            if [[ $macos_major_version -le 10 ]]; then
+                select_query="select client,service,allowed from access"
+            else
+                select_query="select client,service,auth_value from access"
+            fi
+            sudo sqlite3 -column -header "/Library/Application Support/com.apple.TCC/TCC.db" "$select_query"


### PR DESCRIPTION
use `sw_vers` to check the major version of MacOS the script is running in. In the case of Big Sur, it will use the new TCC permissions database schema, otherwise it uses the schema used in previous MacOS versions.

testing will be required to ensure the new values set for `auth_value` and `auth_reason` allow UI testing as expected.