### PR TITLE
Update outdated macos documentation links

### DIFF
--- a/src/commands/add-permission.yml
+++ b/src/commands/add-permission.yml
@@ -16,6 +16,6 @@ steps:
               sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"<< parameters.permission-type >>\",\"<< parameters.bundle-id >>\",0,1,1,\"UNUSED\",0,$epochdate);"
           else
               echo "Unable to add permissions! System Integrity Protection is enabled on this image"
-              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos-apps"
+              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"
               exit 1
           fi

--- a/src/commands/add-uitest-permissions.yml
+++ b/src/commands/add-uitest-permissions.yml
@@ -12,6 +12,6 @@ steps:
               sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceDeveloperTool\",\"com.apple.Terminal\",0,1,1,\"UNUSED\",0,$epochdate);"
           else
               echo "Unable to add permissions! System Integrity Protection is enabled on this image"
-              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos-apps"
+              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"
               exit 1
           fi

--- a/src/commands/delete-permission.yml
+++ b/src/commands/delete-permission.yml
@@ -15,6 +15,6 @@ steps:
               sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "delete from access where (client = \"<< parameters.bundle-id >>\" and service = \"<< parameters.permission-type >>\")"
           else
               echo "Unable to add permissions! System Integrity Protection is enabled on this image"
-              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos-apps"
+              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"
               exit 1
           fi


### PR DESCRIPTION
Updating links for `macos` documentation to point to the right place.
Previous links were `404`.