### PR TITLE
[semver:minor] Add Safari automation command

### DIFF
--- a/src/commands/add-safari-permissions.yml
+++ b/src/commands/add-safari-permissions.yml
@@ -10,7 +10,7 @@ steps:
                 defaults write com.apple.Safari AllowRemoteAutomation 1
               else
                 tcc_service_accessibility="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier_type,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"/usr/sbin/sshd\",1,2,4,1,0,\"UNUSED\",0,$epochdate);"
-                tcc_service_events="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier_type,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAppleEvents\",\"/usr/sbin/sshd\",1,2,4,1,0,\"com.apple.systemevents\",0,$epochdate);"   
+                tcc_service_events="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier_type,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAppleEvents\",\"/usr/sbin/sshd\",1,2,4,1,0,\"com.apple.systemevents\",0,$epochdate);"
                 sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
                 sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
                 sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
@@ -19,7 +19,6 @@ steps:
                   tell application "System Events"
                     tell application "Safari" to activate
                     delay 5
-                    
                     tell process "Safari"
                       set frontmost to true
                       click menu item "Preferences…" of menu 1 of menu bar item "Safari" of menu bar 1

--- a/src/commands/add-safari-permissions.yml
+++ b/src/commands/add-safari-permissions.yml
@@ -1,0 +1,41 @@
+description: Add Safari automation permissions the macOS permissions database and enable safaridriver testing
+steps:
+  - run:
+      name: Granting Safari permissions and enabling safaridriver
+      command: |
+          if csrutil status | grep -q 'disabled'; then
+              epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))
+              macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+              if [[ $macos_major_version -le 10 ]]; then
+                defaults write com.apple.Safari AllowRemoteAutomation 1
+              else
+                tcc_service_accessibility="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier_type,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"/usr/sbin/sshd\",1,2,4,1,0,\"UNUSED\",0,$epochdate);"
+                tcc_service_events="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier_type,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAppleEvents\",\"/usr/sbin/sshd\",1,2,4,1,0,\"com.apple.systemevents\",0,$epochdate);"   
+                sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
+                sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
+                sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
+                sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
+                osascript <<EOD
+                  tell application "System Events"
+                    tell application "Safari" to activate
+                    delay 5
+                    
+                    tell process "Safari"
+                      set frontmost to true
+                      click menu item "Preferences…" of menu 1 of menu bar item "Safari" of menu bar 1
+                      click button "Advanced" of toolbar 1 of window 1
+                      tell checkbox "Show Develop menu in menu bar" of group 1 of group 1 of window 1
+                        if value is 0 then click it
+                      end tell
+                      click button 1 of window 1
+                      click menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
+                    end tell
+                  end tell
+                EOD
+              fi
+              sudo safaridriver --enable
+          else
+              echo "Unable to add permissions! System Integrity Protection is enabled on this image"
+              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"
+              exit 1
+          fi

--- a/src/commands/add-safari-permissions.yml
+++ b/src/commands/add-safari-permissions.yml
@@ -15,7 +15,7 @@ steps:
                 sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
                 sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
                 sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
-                osascript <<EOD
+                osascript \<<EOD
                   tell application "System Events"
                     tell application "Safari" to activate
                     delay 5

--- a/src/commands/add-safari-permissions.yml
+++ b/src/commands/add-safari-permissions.yml
@@ -15,7 +15,7 @@ steps:
                 sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
                 sudo sqlite3 "/Users/distiller/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
                 sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
-                osascript \<<EOD
+                osascript -e '
                   tell application "System Events"
                     tell application "Safari" to activate
                     delay 5
@@ -29,8 +29,7 @@ steps:
                       click button 1 of window 1
                       click menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
                     end tell
-                  end tell
-                EOD
+                  end tell'
               fi
               sudo safaridriver --enable
           else

--- a/src/commands/add-safari-permissions.yml
+++ b/src/commands/add-safari-permissions.yml
@@ -1,4 +1,4 @@
-description: Add Safari automation permissions the macOS permissions database and enable safaridriver testing
+description: Add Safari automation permissions to the macOS permissions database and enable safaridriver testing
 steps:
   - run:
       name: Granting Safari permissions and enabling safaridriver


### PR DESCRIPTION
Sets up Safari for automation with safaridriver. Especially important for Safari 14+ due to the restrictions Apple put in place, meaning this has to use AppleScript to enable automation permissions.