### PR TITLE
[semver:minor] Add pre-boot simulator command

### DIFF
--- a/src/commands/preboot-simulator.yml
+++ b/src/commands/preboot-simulator.yml
@@ -19,5 +19,5 @@ steps:
         ESCAPED_VER=$(echo << parameters.version >> | tr '.' '-')
         ESCAPED_DEVICE=$(echo << parameters.device >> | tr ' ' '-')
         SIMLIST=$(xcrun simctl list -j)
-        UDID=$(echo $SIMLIST | jq -r "".devices.\"com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER\"[] | select(.deviceTypeIdentifier==\"com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE\").udid")
+        UDID=$(echo $SIMLIST | jq -r ".devices.\"com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER\"[] | select(.deviceTypeIdentifier==\"com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE\").udid")
         xcrun simctl boot $UDID

--- a/src/commands/preboot-simulator.yml
+++ b/src/commands/preboot-simulator.yml
@@ -16,8 +16,13 @@ steps:
   - run:
       name: Pre-booting << parameters.device >> << parameters.platform >> << parameters.version >> simulator
       command: |
-        ESCAPED_VER=$(echo << parameters.version >> | tr '.' '-')
-        ESCAPED_DEVICE=$(echo << parameters.device >> | tr ' ' '-')
-        SIMLIST=$(xcrun simctl list -j)
-        UDID=$(echo $SIMLIST | jq -r ".devices.\"com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER\"[] | select(.deviceTypeIdentifier==\"com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE\").udid")
-        xcrun simctl boot $UDID
+        xcode_major=$(/usr/bin/xcodebuild -version | awk 'NR==1{print $2}' | cut -d. -f1)
+        if [[ xcode_major -ge "12" ]]; then
+          ESCAPED_VER=$(echo << parameters.version >> | tr '.' '-')
+          ESCAPED_DEVICE=$(echo << parameters.device >> | tr ' ' '-')
+          SIMLIST=$(xcrun simctl list -j)
+          UDID=$(echo $SIMLIST | jq -r ".devices.\"com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER\"[] | select(.deviceTypeIdentifier==\"com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE\").udid")
+          xcrun simctl boot $UDID
+        else
+          xcrun instruments -w "<< parameters.device >> (<< parameters.version >>) [" || true
+        fi

--- a/src/commands/preboot-simulator.yml
+++ b/src/commands/preboot-simulator.yml
@@ -1,0 +1,22 @@
+description: Boots the iOS simulator with the specific device
+parameters:
+  device:
+    description: The device type. E.g., "iPhone 12"
+    type: string
+    default: "iPhone 12"
+  platform:
+    description: The platform type. Accepts only "iOS", "watchOS", "tvOS"
+    type: string
+    default: "iOS"
+  version:
+    description: The OS version. E.g., "14.5"
+    type: string
+    default: "14.5"
+steps:
+  - run:
+      name: Pre-booting << parameters.device >> << parameters.platform >> << parameters.version >> simulator
+      command: |
+        ESCAPED_VER=$(echo << parameters.version >> | tr '.' '-')
+        ESCAPED_DEVICE=$(echo << parameters.device >> | tr ' ' '-')
+        UDID=$(jq '.devices."com.apple.CoreSimulator.SimRuntime.<< parameter.platform >>-$ESCAPED_VER"[] | select(.deviceTypeIdentifier=="com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE").udid')
+        xcrun simctl boot $UDID

--- a/src/commands/preboot-simulator.yml
+++ b/src/commands/preboot-simulator.yml
@@ -18,5 +18,5 @@ steps:
       command: |
         ESCAPED_VER=$(echo << parameters.version >> | tr '.' '-')
         ESCAPED_DEVICE=$(echo << parameters.device >> | tr ' ' '-')
-        UDID=$(jq '.devices."com.apple.CoreSimulator.SimRuntime.<< parameter.platform >>-$ESCAPED_VER"[] | select(.deviceTypeIdentifier=="com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE").udid')
+        UDID=$(jq '.devices."com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER"[] | select(.deviceTypeIdentifier=="com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE").udid')
         xcrun simctl boot $UDID

--- a/src/commands/preboot-simulator.yml
+++ b/src/commands/preboot-simulator.yml
@@ -18,6 +18,6 @@ steps:
       command: |
         ESCAPED_VER=$(echo << parameters.version >> | tr '.' '-')
         ESCAPED_DEVICE=$(echo << parameters.device >> | tr ' ' '-')
-        UDID=$(echo $(xcrun simctl list -j) | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER"[] | select(.deviceTypeIdentifier=="com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE").udid')
+        SIMLIST=$(xcrun simctl list -j)
+        UDID=$(echo $SIMLIST | jq -r "".devices.\"com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER\"[] | select(.deviceTypeIdentifier==\"com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE\").udid")
         xcrun simctl boot $UDID
-

--- a/src/commands/preboot-simulator.yml
+++ b/src/commands/preboot-simulator.yml
@@ -18,5 +18,6 @@ steps:
       command: |
         ESCAPED_VER=$(echo << parameters.version >> | tr '.' '-')
         ESCAPED_DEVICE=$(echo << parameters.device >> | tr ' ' '-')
-        UDID=$(jq '.devices."com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER"[] | select(.deviceTypeIdentifier=="com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE").udid')
+        UDID=$(echo $(xcrun simctl list -j) | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.<< parameters.platform >>-$ESCAPED_VER"[] | select(.deviceTypeIdentifier=="com.apple.CoreSimulator.SimDeviceType.$ESCAPED_DEVICE").udid')
         xcrun simctl boot $UDID
+


### PR DESCRIPTION
This PR adds a command to pre-boot a simulator in a macOS job.

Example usage:

```
- macos/preboot-simulator:
     version: "15.0"
     platform: "iOS"
     device: "iPhone 13 Pro Max"
```

In newer Xcode versions this will use the `xcrun simctl boot` method as the `instruments` command has recently been deprecated and removed