### PR TITLE
[semver:minor] Add switch Ruby command

### DIFF
--- a/src/commands/switch-ruby.yml
+++ b/src/commands/switch-ruby.yml
@@ -21,5 +21,5 @@ steps:
           elif [[ $xcode_major -eq "11" && $xcode_minor -le "1" ]]; then
             echo "$ruby_version" > ~/.ruby-version
           else
-            echo 'chruby $ruby_version' >> ~/.bash_profile
+            echo "chruby $ruby_version" >> ~/.bash_profile
           fi


### PR DESCRIPTION
This PR adds a command to switch the Ruby version. This command is image-version agnostic to make it easier to switch Rubies regardless of the underlying method that needs to be used - currently in the docs we have 3 different methods for doing this based on the Xcode version.

Example:

```
- macos/switch-ruby:
    version: "2.6"
```

To switch to the system Ruby:

```
- macos/switch-ruby:
    version: "system"
```