### PR TITLE
[semver:minor] Add VoiceOver permissions command

### DIFF
--- a/src/commands/add-voiceover-permissions.yml
+++ b/src/commands/add-voiceover-permissions.yml
@@ -1,0 +1,15 @@
+description: |
+  Enable VoiceOver permissions for testing MacOS apps.
+steps:
+  - run:
+      name: Setting up VoiceOver permissions
+      command: |
+          if csrutil status | grep -q 'disabled'; then
+              defaults write com.apple.VoiceOverTraining doNotShowSplashScreen -bool true
+              defaults write com.apple.VoiceOver4/default SCREnableAppleScript -bool true
+              sudo bash -c 'echo -n "a" > /private/var/db/Accessibility/.VoiceOverAppleScriptEnabled'
+          else
+              echo "Unable to add permissions! System Integrity Protection is enabled on this image"
+              echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"
+              exit 1
+          fi


### PR DESCRIPTION
Fixes #14 

VoiceOver is a screen reader system application that provides auditory descriptions of elements help you easily navigate your screen with keyboard or gestures.

This PR adds a new command `macos/add-voiceover-permissions` for enabling AppleScript control of VoiceOver for accessibility testing of MacOS apps.

Example:

```yml
- macos/add-voiceover-permissions
```