### PR TITLE
Increase and add delays to prevent race conditions in safari automation command

### DIFF
--- a/src/commands/add-safari-permissions.yml
+++ b/src/commands/add-safari-permissions.yml
@@ -18,16 +18,22 @@ steps:
                 osascript -e '
                   tell application "System Events"
                     tell application "Safari" to activate
-                    delay 5
+                    delay 15
                     tell process "Safari"
                       set frontmost to true
+                      delay 5
                       click menu item "Preferences…" of menu 1 of menu bar item "Safari" of menu bar 1
+                      delay 5
                       click button "Advanced" of toolbar 1 of window 1
+                      delay 5
                       tell checkbox "Show Develop menu in menu bar" of group 1 of group 1 of window 1
                         if value is 0 then click it
+                        delay 5
                       end tell
                       click button 1 of window 1
+                      delay 5
                       click menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
+                      delay 5
                     end tell
                   end tell'
               fi


### PR DESCRIPTION
Potentially fixes #23 and #24 by preventing race conditions (particularly on gen1 resource classes)

The delays could be a little shorter, but these numbers seem to be the most consistent