### PR TITLE
chore: change codeowners file to just be images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
-# Ping these folks when changes are made to this repository
-
-- @CircleCI-Public/orb-publishers @CircleCI-Public/images
-
-# We can also add orb-specifc codeowners at some point if desirable
+# Automatically request PR reviews from the CPE Team as a whole and the Images subteam
+*	@CircleCI-Public/images


### PR DESCRIPTION
changes codeowner file to simply be images for now