### PR TITLE
Fix wait until sim booted variable expansion

### DIFF
--- a/src/commands/wait-until-simulator-booted.yml
+++ b/src/commands/wait-until-simulator-booted.yml
@@ -2,7 +2,7 @@ description: Wait until the simulator has booted.
 parameters:
   device-udid-var:
     description: The UDID of the device to wait for
-    type: string
+    type: env_var_name
     default: MACOS_ORB_DEVICE_UDID
 steps:
   - run:

--- a/src/scripts/wait-until-sim-booted.sh
+++ b/src/scripts/wait-until-sim-booted.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-DEVICE_UDID="${ORB_EVAL_DEVICE_UDID}"
+DEVICE_UDID="${!ORB_EVAL_DEVICE_UDID}"
 xcrun simctl bootstatus "${DEVICE_UDID}"

--- a/src/scripts/wait-until-sim-booted.sh
+++ b/src/scripts/wait-until-sim-booted.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-DEVICE_UDID=$(eval "echo $ORB_EVAL_DEVICE_UDID")
+DEVICE_UDID="${ORB_EVAL_DEVICE_UDID}"
 xcrun simctl bootstatus "${DEVICE_UDID}"


### PR DESCRIPTION
The `MACOS_ORB_DEVICE_UDID` parameter was not being expanded correctly and as such this command failed to work correctly, this PR fixes that.