### PR TITLE
chore: better error message when iOS version requested not present

### DIFF
--- a/src/scripts/preboot-sim.sh
+++ b/src/scripts/preboot-sim.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+SIMREQ_not_found() {
+    # arguments: requested simulator runtime
+    echo "ERROR!: Simulator runtime not found"
+    echo "Requested: Simulator Runtime: ${1}"
+    echo "Available Runtimes:"
+    echo "$(echo "${SIMLIST}" | jq -r '.devices | keys[] | select(startswith("com.apple.CoreSimulator.SimRuntime."))')"
+    exit 1
+}
+
 UDID_not_found() {
     # arguments: requested simulator, device
     SIMS=$(xcrun simctl list devices | tail -n +2)
@@ -15,6 +24,10 @@ if [[ $xcode_major -ge "12" ]]; then
     ESCAPED_VER=$(echo "$ORB_VAL_VERSION" | tr '.' '-')
     SIMREQ="${ORB_VAL_PLATFORM}-${ESCAPED_VER}"
     SIMLIST=$(xcrun simctl list -j)
+
+    if ! echo "${SIMLIST}" | jq -e ".devices | has(\"com.apple.CoreSimulator.SimRuntime.${SIMREQ}\")" > /dev/null; then
+        SIMREQ_not_found "${SIMREQ}"
+    fi
 
     UDID=$(echo "${SIMLIST}" | jq -r ".devices.\"com.apple.CoreSimulator.SimRuntime.${SIMREQ}\"[] | select(.name==\"${ORB_VAL_DEVICE}\").udid")
     if [[ -z "${UDID}" ]]; then

--- a/src/scripts/preboot-sim.sh
+++ b/src/scripts/preboot-sim.sh
@@ -5,7 +5,7 @@ SIMREQ_not_found() {
     echo "ERROR!: Simulator runtime not found"
     echo "Requested: Simulator Runtime: ${1}"
     echo "Available Runtimes:"
-    echo "$(echo "${SIMLIST}" | jq -r '.devices | keys[] | select(startswith("com.apple.CoreSimulator.SimRuntime."))')"
+    echo "${SIMLIST}" | jq -r '.devices | keys[] | select(startswith("com.apple.CoreSimulator.SimRuntime."))'
     exit 1
 }
 


### PR DESCRIPTION
thanks for the orb! 

Adds a slightly more helpful error message in the event that the requested iOS version is not installed on the ci machine. Used the function that already exists for a similar purpose as a guideline.

job here failed due to requesting 17.0 when not available: https://app.circleci.com/pipelines/github/artsy/eigen/48271/workflows/cb429968-2f28-4859-bb6e-f54227923dcf/jobs/165451
with error:

```
jq: error (at <stdin>:2499): Cannot iterate over null (null)
Exited with code exit status 5
```

instead fail with something like:

```
ERROR!: Simulator runtime not found
Requested: Simulator Runtime: iOS-18-3
Available Runtimes:
com.apple.CoreSimulator.SimRuntime.iOS-12-4
com.apple.CoreSimulator.SimRuntime.iOS-13-7
com.apple.CoreSimulator.SimRuntime.iOS-14-2
com.apple.CoreSimulator.SimRuntime.iOS-16-4
```