### PR TITLE
Support xcode 15.1+

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -71,6 +71,36 @@ workflows:
   test-deploy:
     jobs:
       - integration-test-xcode:
+          name: "integration-test-xcode-15-3"
+          ruby-version: "3.2"
+          device-name: "iPhone 15"
+          device-platform: "iOS"
+          device-version: "17.4"
+          executor:
+            name: "macos"
+            xcode: "15.3.0"
+          filters: *filters
+      - integration-test-xcode:
+          name: "integration-test-xcode-15-2"
+          ruby-version: "3.2"
+          device-name: "iPhone 15"
+          device-platform: "iOS"
+          device-version: "17.2"
+          executor:
+            name: "macos"
+            xcode: "15.2.0"
+          filters: *filters
+      - integration-test-xcode:
+          name: "integration-test-xcode-15-1"
+          ruby-version: "3.2"
+          device-name: "iPhone 15"
+          device-platform: "iOS"
+          device-version: "17.2"
+          executor:
+            name: "macos"
+            xcode: "15.1.0"
+          filters: *filters
+      - integration-test-xcode:
           name: "integration-test-xcode-15"
           ruby-version: "3.2"
           device-name: "iPhone 15"
@@ -108,6 +138,9 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
+            - integration-test-xcode-15-3
+            - integration-test-xcode-15-2
+            - integration-test-xcode-15-1
             - integration-test-xcode-15
             - integration-test-xcode-14
             - integration-test-xcode-13

--- a/src/commands/enable-vnc.yml
+++ b/src/commands/enable-vnc.yml
@@ -15,3 +15,4 @@ steps:
         ORB_VAL_USERNAME: << parameters.username >>
         ORB_ENV_PASSWORD: << parameters.password >>
       command: << include(scripts/enable-vnc.sh) >>
+      background: true

--- a/src/scripts/add-safari-permissions.sh
+++ b/src/scripts/add-safari-permissions.sh
@@ -12,58 +12,15 @@ if csrutil status | grep -q 'disabled'; then
       sudo sqlite3 "/Users/$USER/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
       sudo sqlite3 "/Users/$USER/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
       sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
-      osascript -e '
-        tell application "System Events"
-          tell application "Safari" to activate
-          delay 15
-          tell process "Safari"
-            set frontmost to true
-            delay 5
-            set settingsLabel to "Preferences…"
-            if menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1 exists then
-              set settingsLabel to "Settings…"
-            end if
-            click menu item settingsLabel of menu 1 of menu bar item "Safari" of menu bar 1
-            delay 5
-            click button "Advanced" of toolbar 1 of window 1
-            delay 5
-            set menuItem to "Show Develop menu in menu bar"
-            if checkbox "Show features for web developers" of group 1 of group 1 of window 1 exists then
-              set menuItem to "Show features for web developers"
-            end if
-            if menuItem is "Show Develop menu in menu bar" then
-              tell checkbox "Show Develop menu in menu bar" of group 1 of group 1 of window 1
-                if value is 0 then click it
-                delay 5
-              end tell
-              click button 1 of window 1
-              delay 5
-              click menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
-              delay 5
-            else
-              tell checkbox "Show features for web developers" of group 1 of group 1 of window 1
-                if value is 0 then click it
-                delay 5
-              end tell
-              click button 1 of window 1
-              delay 5
-              click menu item settingsLabel of menu 1 of menu bar item "Safari" of menu bar 1
-              delay 5
-              click button "Developer" of toolbar 1 of window 1
-              delay 5
-              if checkbox "Allow remote automation" of group 1 of group 1 of window 1 exists then
-                tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
-                  if value is 0 then click it
-                  delay 5
-                end tell
-              end if
-              click button 1 of window 1
-              delay 5
-            end if
-          end tell
-        end tell'
+
+      # enable remote browser automation tool
+      sudo safaridriver --enable
+
+      mkdir -p "$HOME/Library/WebDriver"
+      plist="$HOME/Library/WebDriver/com.apple.Safari.plist"
+      /usr/libexec/PlistBuddy -c 'delete AllowRemoteAutomation' "$plist" || true
+      /usr/libexec/PlistBuddy -c 'add AllowRemoteAutomation bool true' "$plist"
     fi
-    sudo safaridriver --enable
 else
     echo "Unable to add permissions! System Integrity Protection is enabled on this image"
     echo "Please choose an image with SIP disabled. Documentation: https://circleci.com/docs/2.0/testing-macos"

--- a/src/scripts/enable-vnc.sh
+++ b/src/scripts/enable-vnc.sh
@@ -3,46 +3,16 @@
 printf '\nCreating the user account...'
 sudo /usr/sbin/sysadminctl -addUser vncuser -fullName "${ORB_VAL_USERNAME}" -password "${!ORB_ENV_PASSWORD}" -admin
 
-MAC_VER=$(sw_vers -productVersion | cut -d. -f1)
-
 printf '\nGranting automation permissions...'
 EPOCH=$(($(date +'%s * 1000 + %-N / 1000000')))
 TCC="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"/usr/sbin/sshd\",1,2,3,1,\"UNUSED\",0,$EPOCH);"
 sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$TCC"
 sudo sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" "$TCC"
 
-if (( "$MAC_VER" >= 13 )); then
-  printf '\nOpening System Settings...'
-  # Attempt to open the pref pane twice as sometimes it will default to the update pane
-  open x-apple.systempreferences:com.apple.Sharing-Settings.extension
-  sleep 5
-  open x-apple.systempreferences:com.apple.Sharing-Settings.extension
-
-  printf '\nRunning AppleScript. Please wait ~20 seconds...'
-  osascript -e "tell application \"System Events\"
-    tell process \"System Settings\"
-      delay 5
-      click button 1 of group 1 of scroll area 1 of group 1 of group 1 of group 2 of splitter group 1 of group 1 of window \"Sharing\"
-      delay 5
-    end tell
-  end tell"
-
-  sudo killall "System Settings"
-else
-  printf '\nOpening System Preferences...'
-  open -b com.apple.systempreferences /System/Library/PreferencePanes/SharingPref.prefPane
-
-  printf '\nRunning AppleScript. Please wait ~20 seconds...'
-  osascript -e "tell application \"System Events\"
-    tell process \"System Preferences\"
-      delay 5
-      click checkbox 1 of row 7 of table 1 of scroll area 1 of group 1 of window \"Sharing\"
-      delay 5
-    end tell
-  end tell"
-
-  sudo killall "System Preferences"
-fi
+sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
+  -activate -configure -access -on \
+  -clientopts -setvnclegacy -vnclegacy yes \
+  -restart -agent -privs -all
 
 printf '\nDone! To Access VNC (SSH jobs only), run the following command to forward the VNC port:'
 IP=$(ifconfig en0 | awk '/inet / {print $2}')


### PR DESCRIPTION
* Update webdriver remote automation enable step
* Add integration tests for xcode 15.1.0, 15.2.0, 15.3.0
* Make enable-vnc a background step to avoid needing to wait unnecessarily in a non-SSH rerun scenario