### PR TITLE
Redirect `PlistBuddy` output streams to `/dev/null`

### DIFF
--- a/src/scripts/add-safari-permissions.sh
+++ b/src/scripts/add-safari-permissions.sh
@@ -18,8 +18,8 @@ if csrutil status | grep -q 'disabled'; then
 
       mkdir -p "$HOME/Library/WebDriver"
       plist="$HOME/Library/WebDriver/com.apple.Safari.plist"
-      /usr/libexec/PlistBuddy -c 'delete AllowRemoteAutomation' "$plist" || true
-      /usr/libexec/PlistBuddy -c 'add AllowRemoteAutomation bool true' "$plist"
+      /usr/libexec/PlistBuddy -c 'delete AllowRemoteAutomation' "$plist" > /dev/null 2>&1 || true
+      /usr/libexec/PlistBuddy -c 'add AllowRemoteAutomation bool true' "$plist" > /dev/null 2>&1
     fi
 else
     echo "Unable to add permissions! System Integrity Protection is enabled on this image"


### PR DESCRIPTION
This small change redirects the output of `PlistBuddy` to /dev/null to avoid situations where it seems like errors are being generated. The script attempts first to remove a key from plist file, and if it does not exist, the tool outputs that the key could not be removed.

This behaviour is intentional, but it can be confusing to see what are ostensibly errors being reported from a successful step.