### PR TITLE
Fix switch-ruby silent exit when requested Ruby is missing

### DIFF
--- a/src/scripts/switch-ruby.sh
+++ b/src/scripts/switch-ruby.sh
@@ -3,7 +3,8 @@
 if command -v rbenv >/dev/null 2>&1; then
     ruby_ver="$ORB_VAL_RUBY_VERSION"
     if [[ "$ruby_ver" != "system" ]]; then
-        ruby_version=$(rbenv versions --bare | grep "$ORB_VAL_RUBY_VERSION" | head -n 1)
+        # `|| true` so a non-matching grep doesn't abort under `set -eo pipefail`
+        ruby_version=$(rbenv versions --bare | { grep "$ORB_VAL_RUBY_VERSION" || true; } | head -n 1)
         if [[ -z "$ruby_version" ]]; then
             printf "\nNo Rubies installed that match version %s\n" "$ORB_VAL_RUBY_VERSION"
             printf "\nInstalled versions:\n"


### PR DESCRIPTION
### What

`switch-ruby.sh` detects a missing Ruby with:

```sh
ruby_version=$(rbenv versions --bare | grep "$ORB_VAL_RUBY_VERSION" | head -n 1)
```

Under CircleCI's default macOS step shell (`/bin/bash --login -eo pipefail`), when the requested version is **not** installed, `grep` exits 1, `pipefail` propagates that through the pipe, and `set -e` aborts the script **on this assignment line** — before the `if [[ -z "$ruby_version" ]]` block that prints `No Rubies installed…` and lists the installed versions.

The result is a bare `Exited with code exit status 1` with **no diagnostic output**, which is very hard to troubleshoot. See CircleCI-Public/macos-orb#77.

### Fix

Wrap the `grep` so a no-match doesn't trip `pipefail`/`set -e`, letting the existing error-reporting run:

```sh
ruby_version=$(rbenv versions --bare | { grep "$ORB_VAL_RUBY_VERSION" || true; } | head -n 1)
```

Behavior when the version *is* installed is unchanged.

Verified under `bash -eo pipefail`: missing version now reaches the `No Rubies installed` message + version list before exiting 1, instead of exiting silently.

Closes #77